### PR TITLE
exclude tests from dist package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,3 @@ include CHANGES.txt
 include LICENSE.txt
 include MANIFEST.in
 include README.rst
-recursive-include tests *.py

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     keywords='click plugin setuptools entry-point',
     license="New BSD",
     long_description=long_desc,
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     url=source,
     version=version,
     zip_safe=True


### PR DESCRIPTION
I don't think we actually want to install a top-level 'tests' package as part
of click_plugins. This causes issues for other projects that might also
have a 'tests' package in their repo.

Alternatively, tests could be in the `click_plugins.tests` namespace if it's important to ship with tests.
