### PR TITLE
Include tests in package, but don't install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include LICENSE.txt
 include MANIFEST.in
 include README.rst
 include setup.py
+recursive-include tests *.py

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     keywords='click plugin setuptools entry-point',
     license="New BSD",
     long_description=long_desc,
-    packages=find_packages(exclude=['tests']),
+    packages=find_packages(exclude=['tests.*', 'tests']),
     url=source,
     version=version,
     zip_safe=True


### PR DESCRIPTION
@untitaker So this supports bundling the tests with source in the tarball, but prevents them from being installed, correct?

/ cc @campbellr 
