### PR TITLE
Fix link to example section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ sub-group, across multiple sub-groups, or some combination.
 Enabling Plugins
 ----------------
 
-For a more detailed example see the `examples <https://github.com/click-contrib/click-plugins/tree/master/examples>`_ section.
+For a more detailed example see the `examples <https://github.com/click-contrib/click-plugins/tree/master/example>`_ section.
 
 The only requirement is decorating ``click.group()`` with ``click_plugins.with_plugins()``
 which handles attaching external commands and groups.  In this case the core CLI developer


### PR DESCRIPTION
Either the example directory needs to be renamed to `examples`, or this `README.rst` file needs to be modified to point to `example`. I picked the latter.
