### PR TITLE
Click 7 changes how command names are generated.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,29 +1,29 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+*$py.class
 
 # C extensions
 *.so
 
 # Distribution / packaging
 .Python
-env/
-venv/
-venv2/
-venv3/
 build/
 develop-eggs/
 dist/
 downloads/
 eggs/
+.eggs/
 lib/
 lib64/
 parts/
 sdist/
 var/
+wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+MANIFEST
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -38,10 +38,15 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.nox/
 .coverage
+.coverage.*
 .cache
 nosetests.xml
 coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo
@@ -49,6 +54,15 @@ coverage.xml
 
 # Django stuff:
 *.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
 
 # Sphinx documentation
 docs/_build/
@@ -56,5 +70,42 @@ docs/_build/
 # PyBuilder
 target/
 
-# Intellij PyCharm
-.idea/
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ cache:
 
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
+  - 3.6
   - pypy
   - pypy3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - pip install -e .\[dev\]
 
 script:
-  - py.test tests --cov click_plugins --cov-report term-missing
+  - pytest tests --cov click_plugins --cov-report term-missing
 
 after_success:
   - coveralls

--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,7 @@ Developing
     $ git clone https://github.com/click-contrib/click-plugins.git
     $ cd click-plugins
     $ pip install -e .\[dev\]
-    $ py.test tests --cov click_plugins --cov-report term-missing
+    $ pytest tests --cov click_plugins --cov-report term-missing
 
 
 Changelog

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
                 "via setuptools entry-points.",
     extras_require={
         'dev': [
-            'pytest',
+            'pytest>=3',
             'pytest-cov',
             'wheel',
             'coveralls'

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -115,18 +115,18 @@ def test_group_chain(runner):
 
     # Same as above but the sub-group has plugins
     @with_plugins(plugins=iter_entry_points('_test_click_plugins.test_plugins'))
-    @good_cli.group()
+    @good_cli.group(name='sub-cli-plugins')
     def sub_cli_plugins():
         """Sub CLI with plugins."""
         pass
 
-    result = runner.invoke(good_cli, ['sub_cli_plugins'])
+    result = runner.invoke(good_cli, ['sub-cli-plugins'])
     assert result.exit_code is 0
     for ep in iter_entry_points('_test_click_plugins.test_plugins'):
         assert ep.name in result.output
 
     # Execute one of the sub-group's commands
-    result = runner.invoke(good_cli, ['sub_cli_plugins', 'cmd1', 'something'])
+    result = runner.invoke(good_cli, ['sub-cli-plugins', 'cmd1', 'something'])
     assert result.exit_code is 0
     assert result.output.strip() == 'passed'
 


### PR DESCRIPTION
Closes #19.

Click generates CLI command names from function names.  Previously a comman function like `def command_function()` would generate a CLI command called `command_function`.  As ofhttps://github.com/pallets/click/commit/5d1df0e042b2f8b0dee8f6dd9ce74edce331a950 the CLI commad is now called `command-function`.