### PR TITLE
v1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,17 @@ python:
   - 3.6
   - 3.7
 
+env:
+  matrix:
+    - CLICK_VERSION=4.1
+    - CLICK_VERSION=5.1
+    - CLICK_VERSION=6.7
+    - CLICK_VERSION=7
+
 install:
   - pip install coveralls
   - pip install -e .\[dev\]
+  - pip install "click==${CLICK_VERSION}"
 
 script:
   - pytest tests --cov click_plugins --cov-report term-missing

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
 
 install:
   - pip install coveralls
-  - pip install -e .\[dev\]
+  - pip install -e ".[dev]"
   - pip install "click==${CLICK_VERSION}"
 
 script:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Changelog
 
 - Fix an issue where a broken command's traceback would not be emitted - https://github.com/click-contrib/click-plugins/issues/25
 - Bump required click version to `click>=4` - https://github.com/click-contrib/click-plugins/pull/28
+- Runs Travis tests for the latest release of click versions 4 -> 7 - https://github.com/click-contrib/click-plugins/pull/28
 
 1.0.4 - 2018-09-15
 ------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 - Fix an issue where a broken command's traceback would not be emitted - https://github.com/click-contrib/click-plugins/issues/25
+- Bump required click version to `click>=4` - https://github.com/click-contrib/click-plugins/pull/28
 
 1.0.4 - 2018-09-15
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         ],
     },
     include_package_data=True,
-    install_requires=['click>=3.0'],
+    install_requires=['click>=4.0'],
     keywords='click plugin setuptools entry-point',
     license="New BSD",
     long_description=long_desc,


### PR DESCRIPTION
A continuation of https://github.com/click-contrib/click-plugins/pull/27.

This bumps the click requirement from `click>=3` to `click>=4`, however it looks like click v3 has not worked since the last [`click-plugins` release](https://github.com/click-contrib/click-plugins/commit/be19a8862c1dcefc2e5f707d9b0a54b2eb4122b9).  It is possible that just the tests are broken, but given that [click v3 was released 4.5 years ago](https://github.com/pallets/click/blob/master/CHANGES.rst#version-33) it doesn't seem that risky to just drop support in `click-plugins` v1.1.