### PR TITLE
Use entrypoint resolve to not check all the dependencies in the env

### DIFF
--- a/click_plugins/core.py
+++ b/click_plugins/core.py
@@ -34,7 +34,7 @@ def with_plugins(plugins):
 
         for entry_point in plugins or ():
             try:
-                group.add_command(entry_point.load())
+                group.add_command(entry_point.resolve())
             except Exception:
                 # Catch this so a busted plugin doesn't take down the CLI.
                 # Handled by registering a dummy command that does nothing


### PR DESCRIPTION
I can adapt the tests etc. If you agree that this is a workable way and if this issue is indeed a problem you don't want to see.

Fix #31