### PR TITLE
Clearly state PyPI package is no longer maintained

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.1.1.2 - 2025-06-24
+--------------------
+
+- Add a clear note stating that the package is no longer maintained, but the library can be vendored.
+
 1.1.1.1 - 2025-06-24
 --------------------
 

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,10 @@
 click-plugins
 =============
 
+This PyPI package is no longer actively maintained, but the underlying
+library can be vendored. See `homepage <https://github.com/click-contrib/click-plugins>`_
+for more information.
+
 An extension module for `click <https://github.com/pallets/click>`_ to register
 external CLI commands via setuptools entry-points.
 

--- a/click_plugins/__init__.py
+++ b/click_plugins/__init__.py
@@ -24,7 +24,7 @@ entry-points.
 from click_plugins.core import with_plugins
 
 
-__version__ = '1.1.1.1'
+__version__ = '1.1.1.2'
 __author__ = 'Kevin Wurster, Sean Gillies'
 __email__ = 'wursterk@gmail.com, sean.gillies@gmail.com'
 __source__ = 'https://github.com/click-contrib/click-plugins'


### PR DESCRIPTION
Forgot to add a note in https://github.com/click-contrib/click-plugins/pull/39.