### PR TITLE
Fix wording for license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -13,7 +13,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither click-plugins nor the names of its contributors may not be used to
+* Neither click-plugins nor the names of its contributors may be used to
   endorse or promote products derived from this software without specific prior
   written permission.
 


### PR DESCRIPTION
The wording for this part of the license includes an extra negative making it potentially mean the opposite of what is intended.

Reference - standard new BSD License text: https://opensource.org/license/bsd-3-clause.

Separately I believe license checkers (including Github) aren't automatically picking up the license type because of minor tweaks to the wording, which is what triggered me to manually verify the license phrasing. If you might consider adopting the default phrasing it would probably help various tooling work a bit smoother.